### PR TITLE
`token` url-param became `authorization`

### DIFF
--- a/lib/import-github-repo.js
+++ b/lib/import-github-repo.js
@@ -7,7 +7,7 @@ async function importGitHubRepo (state, {authToken, appId, repoName}) {
 
   const response = await axios({
     method: 'post',
-    url: `https://api.glitch.com/project/githubImport?token=${authToken}&projectId=${appId}&repo=${encodeURIComponent(repoName)}`
+    url: `https://api.glitch.com/project/githubImport?authorization=${authToken}&projectId=${appId}&repo=${encodeURIComponent(repoName)}`
   })
 
   state.debug(`${repoName} imported`)


### PR DESCRIPTION
This brings this tool back online, was able to deploy a repo today (combined with #13 from yesterday)